### PR TITLE
Use CodeMirror API for simpler change detection

### DIFF
--- a/pheditor.php
+++ b/pheditor.php
@@ -290,10 +290,12 @@ function files($dir, $first = true)
 
         if (is_dir($dir . DS . $file) && (empty(PATTERN_DIRECTORIES) || preg_match(PATTERN_DIRECTORIES, $file))) {
             $dir_path = str_replace(MAIN_DIR . DS, '', $dir . DS . $file);
+            $dir_path = str_replace("\\", "/", $dir_path);
 
             $data .= '<li class="dir"><a href="#/' . $dir_path . '/" class="open-dir" data-dir="/' . $dir_path . '/">' . $file . '</a>' . files($dir . DS . $file, false) . '</li>';
         } else if (empty(PATTERN_FILES) || preg_match(PATTERN_FILES, $file)) {
             $file_path = str_replace(MAIN_DIR . DS, '', $dir . DS . $file);
+            $file_path = str_replace("\\", "/", $file_path);
 
             $data .= '<li class="file ' . (is_writable($file_path) ? 'editable' : null) . '" data-jstree=\'{ "icon" : "jstree-file" }\'><a href="#/' . $file_path . '" data-file="/' . $file_path . '" class="open-file">' . $file . '</a></li>';
         }

--- a/pheditor.php
+++ b/pheditor.php
@@ -509,6 +509,10 @@ $(function(){
         lint: true
     });
 
+    editor.on("change", function(){
+        window.dataChanged = true;
+    });
+
     $("#files > div").jstree({
         state: { key: "pheditor" },
         plugins: [ "state" ]
@@ -742,12 +746,23 @@ $(function(){
     $(window).on("hashchange", function(){
         var hash = window.location.hash.substring(1);
 
+        if (window.fileLoaded && window.dataChanged) {
+            if (confirm("Discard changes?")) {
+                window.dataChanged = window.fileLoaded = false;
+
+                $(window).trigger("hashchange");
+            } else {
+                return;
+            }
+        }
+
         if (hash.length > 0) {
             if (hash.substring(hash.length - 1) == "/") {
                 var dir = $("a[data-dir='" + hash + "']");
 
                 if (dir.length > 0) {
                     editor.setValue("");
+                    window.fileLoaded = false;
                     $("#path").html(hash);
                     $(".dropdown").find(".save, .reopen, .close").addClass("disabled");
                     $(".dropdown").find(".delete, .rename").removeClass("disabled");
@@ -762,6 +777,9 @@ $(function(){
                         editor.setValue(data);
 
                         editor.setOption("mode", "application/x-httpd-php");
+
+                        window.fileLoaded = true;
+                        window.dataChanged = false;
 
                         if (hash.lastIndexOf(".") > 0) {
                             var extension = hash.substring(hash.lastIndexOf(".") + 1);


### PR DESCRIPTION
`crypto.subtle` in not available on Chrome if not using HTTPS. 

Its make me confuse before realizing that fact. Its run flawless on Firefox, but not on Chrome.

I think its better to use available CodeMirror API for detecting unsaved file.